### PR TITLE
fix: `white-space: nowrap` breaks editing in firefox

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,7 +51,6 @@ input {
 }
 
 #editor {
-    white-space: nowrap;
     border-right: 1px solid #333;
 }
 


### PR DESCRIPTION
and as far as I can see it's not necessary